### PR TITLE
Add a simple progress meter with --verbose

### DIFF
--- a/src/sync_to.h
+++ b/src/sync_to.h
@@ -250,6 +250,10 @@ struct SyncToWorker {
 		while (!finished) {
 			sync_queue.check_aborted(); // check each iteration, rather than wait until the end of the current table; this is a good place to do it since it's likely we'll have no work to do for a short while
 
+			if (verbose) {
+				cout << "." << flush; // simple progress meter
+			}
+
 			verb_t verb;
 			input >> verb;
 


### PR DESCRIPTION
Just displays dots "." while commands are being processed, so the user knows the process hasn't crashed yet.