### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,4 +9,4 @@ charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
-indent_size = 2
+indent_size = 4


### PR DESCRIPTION
Platform-independent way to persist whitespace/line ending configurations: http://editorconfig.org