### PR TITLE
Add '--structure-only' flag

### DIFF
--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -71,8 +71,9 @@ int endpoint_main(int argc, char *argv[]) {
 			bool alter = getenv_default("ENDPOINT_ALTER", true);
 			CommitLevel commit_level = CommitLevel(getenv_default("ENDPOINT_COMMIT_LEVEL", CommitLevel::success));
 			HashAlgorithm hash_algorithm = HashAlgorithm(getenv_default("ENDPOINT_HASH_ALGORITHM", HashAlgorithm::md5));
+			bool structure_only = getenv_default("ENDPOINT_STRUCTURE_ONLY", false);
 
-			sync_to<DatabaseClient>(workers, startfd, database_host, database_port, database_name, database_username, database_password, set_variables, ignore, only, verbose, snapshot, alter, commit_level, hash_algorithm);
+			sync_to<DatabaseClient>(workers, startfd, database_host, database_port, database_name, database_username, database_password, set_variables, ignore, only, verbose, snapshot, alter, commit_level, hash_algorithm, structure_only);
 		}
 	} catch (const sync_error& e) {
 		// the worker thread has already output the error to cerr

--- a/src/ks.cpp
+++ b/src/ks.cpp
@@ -82,6 +82,7 @@ int main(int argc, char *argv[]) {
 		setenv("ENDPOINT_ALTER", options.alter ? "1" : "0", 1);
 		setenv("ENDPOINT_COMMIT_LEVEL", to_string(options.commit_level));
 		setenv("ENDPOINT_HASH_ALGORITHM", to_string(options.hash_algorithm));
+		setenv("ENDPOINT_STRUCTURE_ONLY", to_string(options.structure_only));
 
 		const char *to_args[] = { to_binary.c_str(), "to", nullptr };
 		child_pids.push_back(Process::fork_and_exec(to_binary, to_args));

--- a/src/options.h
+++ b/src/options.h
@@ -9,7 +9,8 @@
 #include "db_url.h"
 
 struct Options {
-	inline Options(): workers(1), verbose(0), snapshot(true), alter(false), commit_level(CommitLevel::success), hash_algorithm(HashAlgorithm::md5) {}
+	inline Options(): workers(1), verbose(0), snapshot(true), alter(false), structure_only(false),
+    commit_level(CommitLevel::success), hash_algorithm(HashAlgorithm::md5) {}
 
 	void help() {
 		cerr <<
@@ -35,6 +36,8 @@ struct Options {
 			"\n"
 			"  --only tables              Comma-separated list of tables to process (causing \n"
 			"                             all others to be ignored).\n"
+			"\n"
+			"  --structure-only           Create the database tables but do not populate them."
 			"\n"
 			"  --filters file.yml         YAML file to read table/column filtering \n"
 			"                             information from (if using --via, this is read at \n"
@@ -109,6 +112,7 @@ struct Options {
 					{ "workers",					required_argument,	NULL,	'w' },
 					{ "ignore",						required_argument,	NULL,	'i' },
 					{ "only",						required_argument,	NULL,	'o' },
+					{ "structure-only", no_argument, NULL, 's' },
 					{ "filters",					required_argument,	NULL,	'l' },
 					{ "set-from-variables",			required_argument,	NULL,	'F' },
 					{ "set-to-variables",			required_argument,	NULL,	'T' },
@@ -157,6 +161,10 @@ struct Options {
 
 					case 'o':
 						only = optarg;
+						break;
+
+					case 's':
+						structure_only = true;
 						break;
 
 					case 'l':
@@ -249,6 +257,7 @@ struct Options {
 	bool alter;
 	CommitLevel commit_level;
 	HashAlgorithm hash_algorithm;
+	bool structure_only;
 	string ignore, only;
 };
 


### PR DESCRIPTION
This will create the table structure without fetching any of the actual
row data.

The purpose of this is so that one can clone only the database
'skeleton', so that the tables can be populated manually.

This will allow 'partial-ks' to run successfully on a machine that
hasn't been kitchen sync'd before, as previously every table had to
exist so that a 'schema.rb' file could be generated.