### PR TITLE
Add mariadb include dir after a rename in Ubuntu 16.04

### DIFF
--- a/cmake/Modules/FindMySQL.cmake
+++ b/cmake/Modules/FindMySQL.cmake
@@ -13,6 +13,8 @@ ENDIF (MYSQL_INCLUDE_DIR)
 FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
   /usr/local/include/mysql
   /usr/include/mysql
+  /usr/include/mariadb
+  /usr/local/include/mariadb
 )
 
 SET(MYSQL_NAMES mysqlclient mysqlclient_r mariadbclient mariadbclient_r)


### PR DESCRIPTION
The location of mysql .h change from /usr/include/mysql in Ubuntu 14.04 to /usr/include/mariadb in Ubuntu16.04