### PR TITLE
Fix compilation on OpenBSD and FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,15 @@ if(NOT APPLE)
 	include_directories(${OPENSSL_INCLUDE_DIRS})
 endif()
 
+# is backtrace in libc?
+if(NOT APPLE)
+	find_package(Backtrace)
+endif()
+
+if(Backtrace_FOUND OR APPLE)
+	ADD_DEFINITIONS("-DUSE_BACKTRACE")
+endif()
+
 # the endpoints do the actual work
 set(ks_endpoint_SRCS src/schema.cpp src/filters.cpp src/abortable_barrier.cpp src/sync_queue.cpp src/xxHash/xxhash.cpp)
 set(ks_endpoint_LIBS ${OPENSSL_LIBRARIES} ${YamlCPP_LIBRARIES} ${Boost_LIBRARIES})
@@ -70,6 +79,9 @@ if (MYSQL_FOUND)
 	set(ks_mysql_SRCS src/ks_mysql.cpp)
 	add_executable(ks_mysql ${ks_mysql_SRCS} ${ks_endpoint_SRCS})
 	target_link_libraries(ks_mysql ${MYSQL_LIBRARIES} ${ks_endpoint_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+	if(Backtrace_FOUND)
+		target_link_libraries(ks_mysql ${Backtrace_LIBRARIES})
+	endif()
 	install(TARGETS ks_mysql RUNTIME DESTINATION bin)
 endif()
 
@@ -83,6 +95,9 @@ if (PostgreSQL_FOUND)
 	set(ks_postgresql_SRCS src/ks_postgresql.cpp)
 	add_executable(ks_postgresql ${ks_postgresql_SRCS} ${ks_endpoint_SRCS})
 	target_link_libraries(ks_postgresql ${PostgreSQL_LIBRARIES} ${ks_endpoint_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+	if(Backtrace_FOUND)
+		target_link_libraries(ks_postgresql ${Backtrace_LIBRARIES})
+	endif()
 	install(TARGETS ks_postgresql RUNTIME DESTINATION bin)
 endif()
 

--- a/src/backtrace.h
+++ b/src/backtrace.h
@@ -1,19 +1,23 @@
 #ifndef BACKTRACE_H
 #define BACKTRACE_H
 
+#ifdef USE_BACKTRACE
 #include <execinfo.h>
 #include <stdlib.h> /* for free() */
 #include <iostream>
 
 using namespace std;
+#endif
 
 static void backtrace()
 {
+#ifdef USE_BACKTRACE
 	void *callers[100];
 	size_t size = backtrace(callers, 100);
 	char **symbols = backtrace_symbols(callers, size);
 	for (size_t i = 0; i < size; i++) cerr << symbols[i] << endl;
 	free(symbols);
+#endif
 }
 
 #endif

--- a/src/message_pack/endian.h
+++ b/src/message_pack/endian.h
@@ -6,7 +6,12 @@
 		#define htonll OSSwapHostToBigInt64
 	#endif
 #else
-	#include <endian.h>
+	#ifdef __FreeBSD__
+		#include <sys/endian.h>
+	#else
+		#include <endian.h>
+	#endif
+
 	#include <arpa/inet.h>
 	#define ntohll be64toh
 	#define htonll htobe64

--- a/src/message_pack/pack.h
+++ b/src/message_pack/pack.h
@@ -13,6 +13,8 @@
 #include "../to_string.h"
 #include "../backtrace.h"
 
+using namespace std;
+
 struct packer_error: public std::runtime_error {
 	packer_error(const std::string &error): runtime_error(error) {}
 };


### PR DESCRIPTION
On OpenBSD, backtrace is not part of libc. libexecinfo can be installed from ports, but the linker needs help to find it. On FreeBSD, the linker will also not automatically find backtrace.

Adjust include for endian.h on FreeBSD.