### PR TITLE
Update help to show correct default ssh cipher

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -30,7 +30,7 @@ struct Options {
 			"                             if you have very fast disks.\n"
 			"\n"
 			"  --cipher                   Specify the cipher when using 'via' option.\n"
-			"                             Defaults to aes-256-gcm.\n"
+			"                             Defaults to aes256-ctr.\n"
 			"\n"
 			"  --workers num              The number of concurrent workers to use at each end.\n"
 			"                             Defaults to 1.\n"


### PR DESCRIPTION
Updated to match the change made in 9a5d980