### PR TITLE
[PART 1] Greet the SSH server with a NOP so database server can be added to known hosts

### DIFF
--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -14,6 +14,10 @@ set<string> split_list(const string &str) {
 
 template<class DatabaseClient>
 int endpoint_main(int argc, char *argv[]) {
+	if (argc > 1 && argv[1] == string("do-nothing")) {
+		return 0;
+	}
+
 	if (argc < 2 || (argv[1] != string("from") && argv[1] != string("to"))) {
 		cerr << "This program is a part of Kitchen Sync.  Instead of running this program directly, run 'ks'.\n";
 		return 1;

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -14,7 +14,7 @@ set<string> split_list(const string &str) {
 
 template<class DatabaseClient>
 int endpoint_main(int argc, char *argv[]) {
-	if (argc < 1 || (argv[1] != string("from") && argv[1] != string("to"))) {
+	if (argc < 2 || (argv[1] != string("from") && argv[1] != string("to"))) {
 		cerr << "This program is a part of Kitchen Sync.  Instead of running this program directly, run 'ks'.\n";
 		return 1;
 	}


### PR DESCRIPTION
This is the first part to #40.

Before this, ks would spin up multiple workers and would not allow any of them
to accept the host key fingerprint.

After this change, the host key prompt is asked before any syncing
actually happens. This ensures that the user always has a chance to
accept the host key fingerprint if necessary.

The SSH greeting will not prompt for anything if the host key
fingerprint is already known.