### PR TITLE
[PART 2] Greet the SSH server with a NOP so database server can be added to known hosts 

### DIFF
--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -14,6 +14,10 @@ set<string> split_list(const string &str) {
 
 template<class DatabaseClient>
 int endpoint_main(int argc, char *argv[]) {
+	if (argc > 1 && argv[1] == string("do-nothing")) {
+		return 0;
+	}
+
 	if (argc < 2 || (argv[1] != string("from") && argv[1] != string("to"))) {
 		cerr << "This program is a part of Kitchen Sync.  Instead of running this program directly, run 'ks'.\n";
 		return 1;

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -14,7 +14,7 @@ set<string> split_list(const string &str) {
 
 template<class DatabaseClient>
 int endpoint_main(int argc, char *argv[]) {
-	if (argc < 1 || (argv[1] != string("from") && argv[1] != string("to"))) {
+	if (argc < 2 || (argv[1] != string("from") && argv[1] != string("to"))) {
 		cerr << "This program is a part of Kitchen Sync.  Instead of running this program directly, run 'ks'.\n";
 		return 1;
 	}

--- a/src/ks.cpp
+++ b/src/ks.cpp
@@ -25,6 +25,29 @@ void be_christmassy() {
 	     << "           | |" << endl;
 }
 
+void greet_remote_server(Options &options, const string &ssh_binary, const string &from_binary) {
+	string from_binary_cmd(from_binary.c_str() + string(" ") + string("do-nothing"));
+
+	const char *ssh_greeting_args[] = {
+		ssh_binary.c_str(),
+		options.via.c_str(),
+		from_binary_cmd.c_str(), nullptr };
+
+	if (options.verbose >= VERY_VERBOSE) {
+		cout << "ssh greeting command:";
+		for (const char **p = ssh_greeting_args; *p; p++) cout << ' ' << (**p ? *p : "''");
+		cout << endl;
+	}
+
+	pid_t pid = Process::fork_and_exec(ssh_binary, ssh_greeting_args);
+	bool success = Process::wait_for_and_check(pid);
+
+	if (!success) {
+		cerr << "failed to perform initial SSH greeting" << endl;
+		return;
+	}
+}
+
 int main(int argc, char *argv[]) {
 	try
 	{
@@ -59,6 +82,10 @@ int main(int argc, char *argv[]) {
 			cout << "from command:";
 			for (const char **p = applicable_from_args; *p; p++) cout << ' ' << (**p ? *p : "''");
 			cout << endl;
+		}
+
+		if (!options.via.empty()) {
+			greet_remote_server(options, ssh_binary, from_binary);
 		}
 
 		vector<pid_t> child_pids;


### PR DESCRIPTION
This is the second part to #38.

This modifies the `ks` client to pass the newly-added `do-nothing` flag to KS at the server end.

A client that passes this `do-nothing` flag will not work with old server versions (prior to my PR).

This means that we must make sure to deploy #38 to all database servers before we roll this PR out to devs.

If we correctly stage #38, roll to DBs, then do this PR, then all clients - new and old, will work with the new servers.