### PR TITLE
Spatial type

### DIFF
--- a/src/ks_mysql.cpp
+++ b/src/ks_mysql.cpp
@@ -435,7 +435,8 @@ string MySQLClient::column_type(const Column &column) {
 		} else {
 			return "datetime";
 		}
-
+	} else if (column.column_type == ColumnTypes::POIN) {
+		return "point";
 	} else {
 		throw runtime_error("Don't know how to express column type of " + column.name + " (" + column.column_type + ")");
 	}
@@ -562,6 +563,8 @@ struct MySQLColumnLister {
 				flags = (ColumnFlags)(flags | mysql_on_update_timestamp);
 			}
 			table.columns.emplace_back(name, nullable, default_type, default_value, ColumnTypes::DTTM, 0, 0, flags);
+		} else if (db_type == "point") {
+			table.columns.emplace_back(name, nullable, default_type, default_value, ColumnTypes::POIN);
 		} else {
 			// not supported, but leave it till sync_to's check_tables_usable to complain about it so that it can be ignored
 			table.columns.emplace_back(name, nullable, default_type, default_value, ColumnTypes::UNKN, 0, 0, ColumnFlags::nothing, db_type);

--- a/src/schema.h
+++ b/src/schema.h
@@ -24,7 +24,7 @@ namespace ColumnTypes {
 	const string DATE = "DATE";
 	const string TIME = "TIME";
 	const string DTTM = "DATETIME";
-	const string POIN = "POINT";
+	const string SPAT = "SPATIAL";
 
 	const string UNKN = "UNKNOWN";
 }
@@ -41,6 +41,15 @@ enum ColumnFlags {
 	mysql_timestamp = 1,
 	mysql_on_update_timestamp = 2,
 	time_zone = 4,
+};
+
+enum SpatialType {
+	geometry = 1,
+	point = 2,
+	linestring = 3,
+	polygon = 4,
+	collection = 8,
+	multi = 16,
 };
 
 struct Column {

--- a/src/schema.h
+++ b/src/schema.h
@@ -24,6 +24,7 @@ namespace ColumnTypes {
 	const string DATE = "DATE";
 	const string TIME = "TIME";
 	const string DTTM = "DATETIME";
+	const string POIN = "POINT";
 
 	const string UNKN = "UNKNOWN";
 }


### PR DESCRIPTION
Here a pull request to correct the @le-zell problem with spatial types in MySQL (cf. #37).

It also include a filter to hide views in MySQL (1dd5ebb) as Kitchen_sync is unable to handle views. Without this, some views can't be correctly ignored and cause crash.

I didn't do the PostgreSQL part for spatial.