### PR TITLE
Only output christmassy output if stdout is a tty.

### DIFF
--- a/src/ks.cpp
+++ b/src/ks.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
 		if (success) {
 			cout << "Finished Kitchen Syncing." << endl;
 			time_t t = time(NULL);
-			if (options.verbose && localtime(&t)->tm_mon == 11) be_christmassy();
+			if (options.verbose && isatty(STDOUT_FILENO) && localtime(&t)->tm_mon == 11) be_christmassy();
 			return 0;
 		} else {
 			cout << "Kitchen Syncing failed." << endl;


### PR DESCRIPTION
I have some cronjobs which ks and use the verbose option. Filtering out the christmas trees from the log output is a bit of a pain :)