### PR TITLE
Ruby 2.7 compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+unreleased
+----------
+* Update ruby test suite to run on ruby 2.7.0
+
 2.0
 ---
 * Change the default `--commit` option to `--commit=often`.  You can still use `--commit=success` to get the old default behavior.

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -20,4 +20,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -4,9 +4,9 @@ GEM
     msgpack (1.2.4)
     mysql2 (0.5.2)
     pg (1.1.3)
-    power_assert (1.1.3)
+    power_assert (1.1.6)
     ruby-xxHash (0.4.0.1)
-    test-unit (3.2.8)
+    test-unit (3.3.5)
       power_assert
 
 PLATFORMS
@@ -20,4 +20,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.16.4
+   2.1.4

--- a/test/column_types_to_test.rb
+++ b/test/column_types_to_test.rb
@@ -13,8 +13,8 @@ class ColumnTypesToTest < KitchenSync::EndpointTestCase
 
     execute %Q{INSERT INTO misctbl (pri, boolfield, datefield, timefield, datetimefield, floatfield, doublefield, decimalfield, vchrfield, fchrfield, uuidfield, textfield, blobfield, jsonfield, enumfield) VALUES
                                    (-21, true, '2099-12-31', '12:34:56', '2014-04-13 01:02:03', 1.25, 0.5, 123456.4321, 'vartext', 'fixedtext', 'e23d5cca-32b7-4fb7-917f-d46d01fbff42', 'sometext', 'test', '{"one": 1, "two": "test"}', 'green')} # insert the first row but not the second
-    @rows = [[-21,  true, Date.parse('2099-12-31'), TimeOnlyWrapper.new('12:34:56'), Time.parse('2014-04-13 01:02:03'), HashAsStringWrapper.new(1.25), HashAsStringWrapper.new(0.5), BigDecimal.new('123456.4321'), 'vartext', 'fixedtext', 'e23d5cca-32b7-4fb7-917f-d46d01fbff42', 'sometext', 'test',           '{"one": 1, "two": "test"}', 'green'],
-             [ 42, false, Date.parse('1900-01-01'), TimeOnlyWrapper.new('00:00:00'), Time.parse('1970-02-03 23:59:59'), HashAsStringWrapper.new(1.25), HashAsStringWrapper.new(0.5), BigDecimal.new('654321.1234'), 'vartext', 'fixedtext', 'c26ae0c4-b071-4058-9044-92042d6740fc', 'sometext', "binary\001test", '{"somearray": [1, 2, 3]}',  "with'quote"]]
+    @rows = [[-21,  true, Date.parse('2099-12-31'), TimeOnlyWrapper.new('12:34:56'), Time.parse('2014-04-13 01:02:03'), HashAsStringWrapper.new(1.25), HashAsStringWrapper.new(0.5), BigDecimal('123456.4321'), 'vartext', 'fixedtext', 'e23d5cca-32b7-4fb7-917f-d46d01fbff42', 'sometext', 'test',           '{"one": 1, "two": "test"}', 'green'],
+             [ 42, false, Date.parse('1900-01-01'), TimeOnlyWrapper.new('00:00:00'), Time.parse('1970-02-03 23:59:59'), HashAsStringWrapper.new(1.25), HashAsStringWrapper.new(0.5), BigDecimal('654321.1234'), 'vartext', 'fixedtext', 'c26ae0c4-b071-4058-9044-92042d6740fc', 'sometext', "binary\001test", '{"somearray": [1, 2, 3]}',  "with'quote"]]
     @keys = @rows.collect {|row| [row[0]]}
 
     expect_handshake_commands(schema: {"tables" => [misctbl_def]})


### PR DESCRIPTION
Was looking at some other kitchen_sync things when I noticed the tests cannot run under ruby 2.7. This MR remedies that.

I'm not sure if you're targeting a set of ruby versions. The only mention I found was that it must run at least ruby 2.0. The changes here should run in all versions from ruby 2.0 on up to the current 2.7.

I am indifferent regarding the `BUNDLED WITH` change. I'll leave that up to you to decide.