### PR TITLE
Cmake v4 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
+# Minimum supported version
+cmake_minimum_required(VERSION 3.5...4.0)
+
 # Kitchen Sync is all C++, but Threads requires C to be enabled to figure out what options to use
 project(kitchen_sync CXX C)
-
-cmake_minimum_required(VERSION 3.1)
 
 # turn on debugging symbols
 set(CMAKE_BUILD_TYPE Debug)

--- a/src/yaml-cpp/CMakeLists.txt
+++ b/src/yaml-cpp/CMakeLists.txt
@@ -1,5 +1,6 @@
-# 3.5 is actually available almost everywhere, but this a good minimum
-cmake_minimum_required(VERSION 3.4)
+# 3.5 is actually available almost everywhere, but this a good minimum.
+# 3.14 as the upper policy limit avoids CMake deprecation warnings.
+cmake_minimum_required(VERSION 3.4...3.14)
 
 # enable MSVC_RUNTIME_LIBRARY target property
 # see https://cmake.org/cmake/help/latest/policy/CMP0091.html


### PR DESCRIPTION
Minimal changes for KS to build with CMake v4.

v4 is now the default cmake [distributed by Homebrew](https://github.com/Homebrew/homebrew-core/blob/5ef6594297f60b295b5c51e42c4f2287b71073b9/Formula/c/cmake.rb). It's backward compatibility with prior versions extends only as far [back as 3.5 now](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features). 

Additionally pulled in the [similar change](https://github.com/jbeder/yaml-cpp/pull/1211) from the yaml-cpp library and their range of compatibility. Ideally these would be matched to KS, but thought this was a reasonable compromise.