### PR TITLE
Add include for stdint.h

### DIFF
--- a/src/message_pack/packed_buffer.h
+++ b/src/message_pack/packed_buffer.h
@@ -2,6 +2,7 @@
 #define PACKED_BUFFER_H
 
 #include <string.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdexcept>
 


### PR DESCRIPTION
Saw a build error on Ubuntu 24.04 / GCC 13
```
/tmp/kitchen-sync-20250412-23682-pnapg9/kitchen_sync-2.20/src/message_pack/packed_buffer.h:54:16: error: 'uint8_t' does not name a type
   54 |         inline uint8_t *extend(size_t bytes) {
      |                ^~~~~~~
/tmp/kitchen-sync-20250412-23682-pnapg9/kitchen_sync-2.20/src/message_pack/packed_buffer.h:6:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    5 | #include <stdlib.h>
  +++ |+#include <cstdint>
    6 | #include <stdexcept>
```

Went with C header instead of GCC's recommendation as it seems like other headers are C variants.